### PR TITLE
Added Callback Hook: ajax_dropdowns_callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,47 @@
 ajax-dropdowns
 ==============
+* Contributors: brianmiyaji, twinpictures
+* Tags: ajax, dropdowns, option, posts, pages, custom post types, tabs, groups, redirect, inline
+* Requires at least: 3.0
+* Tested up to: 4.9.1
+* Stable tag: 0.9.9
+* License: GPLv2 or later
+* License URI: http://www.gnu.org/licenses/gpl-2.0.html
+
+Description
+-----------
+Add content from multiple post types on one page with a dropdown to switch between them. Dropdowns are displayed on the frontend of your site and can query posts via Ajax, inline, or redirection.
+
+= Features =
+* Create unlimited dropdowns
+* Display on any post or page using the included shortcode
+* Drag and drop posts to reorder them within a dropdown
+* Decrease page load by dynamically querying posts via Ajax
+* Use inline dropdowns to quickly switch between posts
+* Redirection method also available
+
+= Get Involved =
+Developers can contribute via the [Ajax Dropdowns GitHub Repository](https://github.com/ThemeBoy/ajax-dropdowns).
+Translators can contribute new languages to Ajax Dropdowns and our other WordPress plugins through [Transifex](https://www.transifex.com/projects/p/wp-plugins/).
+
+Installation
+------------
+= Minimum Requirements =
+* WordPress 3.0 or greater
+* PHP version 5.2.4 or greater
+* MySQL version 5.0 or greater
+
+= Automatic Installation =
+Automatic installation is the easiest option as WordPress handles the file transfers itself and you don’t even need to leave your web browser. To do an automatic install of Ajax Dropdown, log in to your WordPress admin panel, navigate to the Plugins menu and click Add New.
+
+In the search field type "Ajax Dropdown" and click Search Plugins. Once you’ve found the plugin you can view details about it such as the point release, rating and description. Most importantly of course, you can install it by simply clicking Install Now. After clicking that link you will be asked if you’re sure you want to install the plugin. Click yes and WordPress will automatically complete the installation.
+
+= Manual Installation =
+The manual installation method involves downloading the plugin and uploading it to your webserver via your favorite FTP application.
+
+1. Download the plugin file to your computer and unzip it
+1. Using an FTP program, or your hosting control panel, upload the unzipped plugin folder to your WordPress installation’s wp-content/plugins/ directory.
+1. Activate the plugin from the Plugins menu within the WordPress admin.
+
+= Upgrading =
+Automatic updates should work like a charm; as always though, ensure you backup your site just in case.

--- a/ajax-dropdowns.php
+++ b/ajax-dropdowns.php
@@ -1,14 +1,14 @@
 <?php
 /**
  * @package Ajax_Dropdowns
- * @version 0.9.8
+ * @version 0.9.9
  */
 /*
 Plugin Name: Ajax Dropdowns
 Plugin URI: http://wordpress.org/plugins/ajax-dropdowns/
 Description: Display a group of posts that can be switched using dropdowns.
 Author: Brian Miyaji
-Version: 0.9.8
+Version: 0.9.9
 Author URI: http://themeboy.com/
 */
 
@@ -52,7 +52,7 @@ class Ajax_Dropdowns {
 	*/
 	private function define_constants() {
 		if ( !defined( 'AJAX_DROPDOWNS_VERSION' ) )
-			define( 'AJAX_DROPDOWNS_VERSION', '0.9.8' );
+			define( 'AJAX_DROPDOWNS_VERSION', '0.9.9' );
 
 		if ( !defined( 'AJAX_DROPDOWNS_URL' ) )
 			define( 'AJAX_DROPDOWNS_URL', plugin_dir_url( __FILE__ ) );
@@ -369,7 +369,7 @@ class Ajax_Dropdowns {
 			$select .= '<option value="' . $post_id . '" data-permalink="' . get_permalink( $post_id ) . '" ' . selected( $current, $post_id, false ) . '>' . get_the_title( $post_id ) . '</option>';
 		endif; endforeach;
 		$select .= '</select>';
-		
+
 		/**
 		 * Select script (defaults to ajax)
 		 */
@@ -450,6 +450,9 @@ class Ajax_Dropdowns {
 			echo '<div class="ajaxd-post" id="ajaxd-post-' . $post_id . '">' . apply_filters( 'the_content', get_the_content() ) . '</div>';
 
 		endwhile;
+
+		// Add callback hook to play well with others
+		do_action('ajax_dropdowns_callback');
 
 		die();
 	}

--- a/readme.txt
+++ b/readme.txt
@@ -1,10 +1,11 @@
 === Ajax Dropdowns ===
-Contributors: brianmiyaji
+Contributors: brianmiyaji, twinpictures
 Tags: ajax, dropdowns, option, posts, pages, custom post types, tabs, groups, redirect, inline
 Requires at least: 3.0
-Tested up to: 4.7
-Stable tag: 0.9.8
+Tested up to: 4.9.1
+Stable tag: 0.9.9
 License: GPLv2 or later
+License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
 Display a group of posts that can be switched using dropdowns.
 
@@ -61,6 +62,9 @@ Automatic updates should work like a charm; as always though, ensure you backup 
 6. A dropdown is displayed on the frontend to swap the content below it.
 
 == Changelog ==
+
+= 0.9.9 =
+* Feature - Added callback on successful content load.
 
 = 0.9.8 =
 * Fix - Automatically display content of first option in widget.


### PR DESCRIPTION
Allows other plugins to trigger functions once the content has been successfully loaded via AJAX.

See the following threads for background info:
https://wordpress.org/support/topic/always-expanded-when-displayed-with-ajax/
https://wordpress.org/support/topic/hooking-into-ajax_callback/